### PR TITLE
[Feat] 챕터 페이지에서 (자료구조, 알고리즘, 네트워크) 외의 챕터 비활성화

### DIFF
--- a/src/features/learning/ChapterCard.tsx
+++ b/src/features/learning/ChapterCard.tsx
@@ -4,40 +4,69 @@ import LessonProgressBar from "@/entities/learning/ui/LessonProgressBar";
 import { getPlanetImage } from "@/shared/lib/planet/utils";
 import Tooltip from "@/shared/ui/tooltip/Tooltip";
 import type { Chapter } from "@/entities/learning/model/types";
+import { cn } from "@/shared/lib/cn";
 
-function ChapterCard({ chapter }: { chapter: Chapter }) {
+function ChapterCard({
+	chapter,
+	isActive,
+}: {
+	chapter: Chapter;
+	isActive: boolean;
+}) {
 	const { chapterId, title, description, progressRate } = chapter;
 	return (
 		<article
 			key={chapterId}
-			className="cursor-pointer relative flex flex-col justify-between lg:justify-start w-full h-64 lg:h-fit lg:aspect-square bg-cover bg-center rounded-[10px] overflow-hidden p-4 group shadow-[4px_4px_4px_0px_rgba(0,0,0,0.1)]"
+			className={cn(
+				"relative flex flex-col justify-between lg:justify-start w-full h-64 lg:h-fit lg:aspect-square bg-cover bg-center rounded-[10px] overflow-hidden p-4 group shadow-[4px_4px_4px_0px_rgba(0,0,0,0.1)]",
+				isActive ? "cursor-pointer " : "cursor-auto",
+			)}
 			style={{ backgroundImage: `url(${cardBackground})` }}
 		>
 			<div className="flex flex-row justify-between lg:mb-3 z-10">
-				<h3 className="text-3xl xl:text-4xl font-mbc text-white">{title}</h3>
-				<Tooltip
-					button={
-						<div>
-							<InfoCircle className="relative ml-auto mt-0.5 w-7 h-7 mb-0" />
-						</div>
-					}
-					positionX="RIGHT"
+				<h3
+					className={cn(
+						"text-3xl xl:text-4xl font-mbc text-white",
+						!isActive && "opacity-60",
+					)}
 				>
-					<div className="relative z-50 flex items-center justify-center gap-2.5 w-[300px]">
-						<InfoCircle className="w-7 h-7 shrink-0" />
-						<p className="text-white text-[16px] font-normal flex-wrap">
-							{description}
-						</p>
-					</div>
-				</Tooltip>
+					{title}
+				</h3>
+				{isActive && (
+					<Tooltip
+						button={
+							<div>
+								<InfoCircle className="relative ml-auto mt-0.5 w-7 h-7 mb-0" />
+							</div>
+						}
+						positionX="RIGHT"
+					>
+						<div className="relative z-50 flex items-center justify-center gap-2.5 w-[300px]">
+							<InfoCircle className="w-7 h-7 shrink-0" />
+							<p className="text-white text-[16px] font-normal flex-wrap">
+								{description}
+							</p>
+						</div>
+					</Tooltip>
+				)}
 			</div>
-			<LessonProgressBar progressRate={progressRate} className="w-full" />
+			{isActive && (
+				<LessonProgressBar progressRate={progressRate} className="w-full" />
+			)}
 			<img
 				src={getPlanetImage(chapterId)}
-				className="absolute w-[60%] h-auto lg:w-[65%] top-1/3 transform right-0 translate-x-3 lg:top-1/2 lg:translate-x-7 group-hover:-rotate-20 group-hover:scale-110 transition-all ease-out duration-500"
+				className={cn(
+					"absolute w-[60%] h-auto lg:w-[65%] top-1/3 transform right-0 translate-x-3 lg:top-1/2 lg:translate-x-7",
+					isActive &&
+						"group-hover:-rotate-20 group-hover:scale-110 transition-all ease-out duration-500",
+				)}
 				alt={`${title} 행성`}
 			/>
-			<div className="absolute inset-0 bg-black/20 group-hover:opacity-0 transition-all ease-out duration-500 z-0"></div>
+			{isActive ? (
+				<div className="absolute inset-0 bg-black/20 group-hover:opacity-0 transition-all ease-out duration-500 z-0"></div>
+			) : (
+				<div className="absolute inset-0 bg-black/60  z-0"></div>
+			)}
 		</article>
 	);
 }

--- a/src/pages/_authenticated/_fixed-header-layout/learning/index.tsx
+++ b/src/pages/_authenticated/_fixed-header-layout/learning/index.tsx
@@ -35,16 +35,23 @@ function RouteComponent() {
 						</button>
 					</nav>
 					<section className="w-full grid grid-cols-1 lg:grid-cols-3 2xl:grid-cols-4 gap-8 lg:gap-10 mb-10">
-						{chapters.map((chapter) => {
+						{chapters.map((chapter, idx) => {
+							const isActive = idx <= 2;
 							return (
-								<Link
-									to={"/learning/$chapterId"}
-									params={{ chapterId: String(chapter.chapterId) }}
-									key={chapter.chapterId}
-									className="w-full"
-								>
-									<ChapterCard chapter={chapter} />
-								</Link>
+								<>
+									{isActive ? (
+										<Link
+											to={"/learning/$chapterId"}
+											params={{ chapterId: String(chapter.chapterId) }}
+											key={chapter.chapterId}
+											className="w-full"
+										>
+											<ChapterCard chapter={chapter} isActive={isActive} />
+										</Link>
+									) : (
+										<ChapterCard chapter={chapter} isActive={isActive} />
+									)}
+								</>
 							);
 						})}
 					</section>


### PR DESCRIPTION
## 🔍 작업 유형

<!-- 해당하는 항목에 x 표시 -->

-   [x] 🛠 feat (새로운 기능)

## 📄 작업 내용

<!-- 이번 PR에서 변경된 내용을 설명해주세요 -->
- 챕터 카드 비활성화를 구현했습니다.

## 🔗 관련 이슈

<!-- 관련된 이슈가 있다면 링크해주세요 -->
- #82 


## ✅ 체크리스트

-   [x] 코드가 정상적으로 동작합니다
-   [x] 변경 사항이 기존 기능에 영향을 주지 않습니다
-   [ ] 새로운 테스트를 추가했습니다 (해당하는 경우)
-   [ ] 문서를 업데이트했습니다 (해당하는 경우)

## 🖼️ 🖥 구현 결과 (선택사항)

<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

<img width="1907" height="904" alt="image" src="https://github.com/user-attachments/assets/4ea50934-a16f-46a3-aeb9-a1b08a8a2672" />


## ✔ 리뷰 요구사항

<!-- 리뷰어에게 요청하고 싶은 부분을 작성해주세요 -->

- 일단 급하게 처리하다 보니, 컴포넌트 분리나 구조화같은 건 신경을 안썼습니다! 추후에 리팩토링하겠습니다.
- 현재는 인덱스로 활성화된 챕터인지 비활성화된 챕터인지를 확인하고 있는데, 이 부분도 추후에 수정하겠습니다.

## 📋 참고 문서

<!-- 참고 문서가 있다면 작성해주세요 -->
